### PR TITLE
Flag repeats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "8"

--- a/lib/flagger.js
+++ b/lib/flagger.js
@@ -13,7 +13,7 @@ const Joi = require('joi');
  * @param  {Object} `args` - configuration for a new Flagger instance.
  *   `args` requires:
  *     - `flag`   {String}: What string to use when adding a flag.
- *     - `type`   {String}: What type of check on values to run. Must be one of 'exact', 'set', or 'range'.
+ *     - `type`   {String}: What type of check on values to run. Must be one of 'exact', 'set', 'range', or 'repeats'.
  *     - `value`  {Number}: When type is 'exact', `value` is required.
  *     - `values` {Array}: When type is 'set', `values` is required.
  *     - `start`  {Object}: When type is 'range', `start` is required.
@@ -128,7 +128,7 @@ class Flagger {
     // Base case
     if (data.length === 0) return results;
 
-    // If we have more than one item, setup variables for our repeat-checking loop
+    // Setup variables for our repeat-checking loop
     let currentIndex = 0;
     let currentItem = {...data[0]};
     let nextItem = data[currentIndex+1];
@@ -143,7 +143,7 @@ class Flagger {
     }
 
     if (currentIndex === 0) {
-      results.push(currentItem); // This item
+      results.push(currentItem);
     } else {
       currentSequence.push(currentItem);
       currentSequence.forEach((item, idx) => {

--- a/lib/flagger.js
+++ b/lib/flagger.js
@@ -135,7 +135,6 @@ class Flagger {
     if (currentIndex === 0) {
       results.push(currentItem); // This item
     } else {
-      // Add the last item, that was already identified as part of this sequence
       currentSequence.push(currentItem);
       currentSequence.forEach((item, idx) => {
         let flaggedItem = {...item};

--- a/lib/flagger.js
+++ b/lib/flagger.js
@@ -64,7 +64,7 @@ class Flagger {
    * `addFlag` adds a flag object to the datum flags field if the item matches the flagger criteria.
    *
    * @param {Object} `datum` - expected to have a value field
-   * @returns {Object} `datum` - same as input datum, but potentially having a new flag in a `flags` field.
+   * @return {Object} `datum` - same as input datum, but potentially having a new flag in a `flags` field.
    */
   addFlag(datum, additionalFlags = {}) {
     let addFlag = false;
@@ -114,6 +114,16 @@ class Flagger {
     return datum;
   }
 
+  /**
+   * `flagRepeats` flags sequences of the same value.
+   *
+   * `flagRepeats` uses the first item in the `data` argument flag sequence of items with the same value.
+   * As it checks for repeats, it "shifts" the initial data array on recursive calls.
+   *
+   * @param  {Array} data    Initial array of data items. Upon last call it should be the empty array.
+   * @param  {Array} results Starts empty, values from data are added on recursive calls to flagRepeats
+   * @return {Array}         Final `results` array, populated from initial data array.
+   */
   flagRepeats(data, results = []) {
     // Base case
     if (data.length === 0) return results;

--- a/lib/flagger.js
+++ b/lib/flagger.js
@@ -115,17 +115,15 @@ class Flagger {
   }
 
   flagRepeats(data, results = []) {
-    if (data.length === 1) {
-      results.push(data[0]);
-      return results;
-    }
+    // Base case
     if (data.length === 0) return results;
 
-    let currentItem = {...data[0]};
-    const currentValue = currentItem.value;
+    // If we have more than one item, setup variables for our repeat-checking loop
     let currentIndex = 0;
-    let currentSequence = [];
+    let currentItem = {...data[0]};
     let nextItem = data[currentIndex+1];
+    let currentSequence = [];
+    const currentValue = currentItem.value;
 
     while (nextItem && currentValue === nextItem.value) {
       currentSequence.push(currentItem);
@@ -135,11 +133,10 @@ class Flagger {
     }
 
     if (currentIndex === 0) {
-      results.push(currentItem);
+      results.push(currentItem); // This item
     } else {
-      // we need to add the last thing
-      const nextItem = {...data[currentIndex]};
-      currentSequence.push(nextItem);
+      // Add the last item, that was already identified as part of this sequence
+      currentSequence.push(currentItem);
       currentSequence.forEach((item, idx) => {
         let flaggedItem = {...item};
         if ((this.config.repeatMinimum === undefined) || (currentSequence.length >= this.config.repeatMinimum)) {
@@ -148,7 +145,7 @@ class Flagger {
         results.push(flaggedItem);
       });
     }
-    return this.flagRepeats(data.slice(currentIndex += 1, data.length), results);
+    return this.flagRepeats(data.slice(currentIndex+=1, data.length), results);
   }
 
   /**

--- a/lib/flagger.js
+++ b/lib/flagger.js
@@ -24,7 +24,7 @@ class Flagger {
   constructor(args = {}) {
     const schema = Joi.object().keys({
       flag: Joi.string().required(),
-      type: Joi.any().valid('exact', 'set', 'range').required(),
+      type: Joi.any().valid('exact', 'set', 'range', 'repeats').required(),
       value: Joi.number().when('type', {is: 'exact', then: Joi.required()}),
       values: Joi.array().when('type', {is: 'set', then: Joi.required()}),
       start: Joi.object()
@@ -36,7 +36,8 @@ class Flagger {
         .keys({
           value: Joi.number().required(),
           exclusive: Joi.boolean()
-        })
+        }),
+      repeatMinimum: Joi.number().positive()
     })
     .when(Joi.object({ start: Joi.exist(), end: Joi.exist() }).unknown(), {
       then: Joi.object({
@@ -65,7 +66,7 @@ class Flagger {
    * @param {Object} `datum` - expected to have a value field
    * @returns {Object} `datum` - same as input datum, but potentially having a new flag in a `flags` field.
    */
-  addFlag(datum) {
+  addFlag(datum, additionalFlags = {}) {
     let addFlag = false;
     switch (this.config.type) {
       case 'exact': {
@@ -98,15 +99,56 @@ class Flagger {
         addFlag = isNumber && isGreaterOrEqualToStart() && isLessOrEqualToEnd();
         break;
       }
+      case 'repeats': {
+        addFlag = true;
+        break;
+      }
       default: {
         break;
       }
     }
     if (addFlag) {
       datum.flags = datum.flags || [];
-      datum.flags.push({flag: this.config.flag});      
+      datum.flags.push({...additionalFlags, flag: this.config.flag});
     }
     return datum;
+  }
+
+  flagRepeats(data, results = []) {
+    if (data.length === 1) {
+      results.push(data[0]);
+      return results;
+    }
+    if (data.length === 0) return results;
+
+    let currentItem = {...data[0]};
+    const currentValue = currentItem.value;
+    let currentIndex = 0;
+    let currentSequence = [];
+    let nextItem = data[currentIndex+1];
+
+    while (nextItem && currentValue === nextItem.value) {
+      currentSequence.push(currentItem);
+      currentIndex += 1;
+      currentItem = {...data[currentIndex]};
+      nextItem = {...data[currentIndex+1]};
+    }
+
+    if (currentIndex === 0) {
+      results.push(currentItem);
+    } else {
+      // we need to add the last thing
+      const nextItem = {...data[currentIndex]};
+      currentSequence.push(nextItem);
+      currentSequence.forEach((item, idx) => {
+        let flaggedItem = {...item};
+        if ((this.config.repeatMinimum === undefined) || (currentSequence.length >= this.config.repeatMinimum)) {
+          flaggedItem = this.addFlag(item, {sequenceNumber: idx+1})
+        }
+        results.push(flaggedItem);
+      });
+    }
+    return this.flagRepeats(data.slice(currentIndex += 1, data.length), results);
   }
 
   /**
@@ -116,6 +158,10 @@ class Flagger {
    * @return {Array} Same data as input argument, but with flags fields added.
    */
   flag(data) {
+    if (this.config.type === 'repeats') {
+      return this.flagRepeats(data);
+    }
+
     return data.map((datum) => {
       // datum is a reference to each object in data, so make a copy.
       let flaggedDatum = {...datum};

--- a/tests/flagger-test.js
+++ b/tests/flagger-test.js
@@ -242,14 +242,34 @@ test('flags repeat values when repeated at least repeatMinimum times', t => {
 });
 
 test('flags multiple sets of repeats, restarting sequenceNumber', t => {
-  const dataWithMulitipleRepeats = [{value: 1}, {value: 1}, {value: 2}, {value: 2}];
+  const dataWithMulitipleRepeats = [
+    {
+      id: 2,
+      value: 1
+    }, {
+      id: 3,
+      value: 1
+    }, {
+      id: 4,
+      value: 2
+    }, {
+      id: 5,
+      value: 2
+    }
+  ];
   const flagger = new Flagger({...repeatsFlaggerProperties});
   const flaggedData = flagger.flag(dataWithMulitipleRepeats);
   const expectedFlag = {flag: 'F'};
-  flaggedData.slice(0,2).forEach((datum, idx) => {
-    t.deepEqual(datum.flags[0], {...expectedFlag, sequenceNumber: idx+1})
-  });
-  flaggedData.slice(2,4).forEach((datum, idx) => {
-    t.deepEqual(datum.flags[0], {...expectedFlag, sequenceNumber: idx+1})
+  flaggedData.forEach((datum, idx) => {
+    t.deepEqual(datum, {
+      id: idx+2,
+      value: dataWithMulitipleRepeats[idx].value,
+      flags: [
+        {
+          ...expectedFlag,
+          sequenceNumber: Math.floor(idx%2)+1
+        }
+      ]
+    });
   });
 });


### PR DESCRIPTION
**Summary:** Adds functionality to `Flagger` to flag repeats.

## Changes

* Adds `repeats` configuration option
* Adds `flagRepeats` function to `Flagger` which flags sequences of the same value in array
* Adds tests for `flagRepeats`
* Adds travis CI configuration file
* Refactors some tests to be more DRY

## Test Plan
- [x] Unit tests
