### PR TITLE
Make executable and schema agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,29 @@ Have an OpenAQ data quality concern or experience you would like to share? Pleas
 
 ## Use
 
-### Prerequisits
+### Prerequisites
 
 * [node, npm, nvm](https://docs.npmjs.com/getting-started/installing-node)
 * [jq](https://stedolan.github.io/jq/) is recommended if using json.
 
-### Installation
+### Install
 
 ```
 nvm use 8.9.4
 npm install openaq-quality-checker -g
 ```
 
-### Development
+### Develop
 
 ```bash
+git clone https://github.com/openaq/openaq-quality-checks
+cd openaq-quality-checks
 nvm use
 yarn install
 yarn test
 ```
 
-### Example Usage
+### Configuration
 
 openaq-quality-checks expects a list of items, either in json or csv.
 
@@ -48,6 +50,8 @@ keyTwo:
 ```
 
 This configuration is merged with the default configuration, overriding fields that exist and adding fields that do not exist.
+
+### Example Commands
 
 #### Read and output JSON
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Have an OpenAQ data quality concern or experience you would like to share? Pleas
 ### Prerequisits
 
 * [node, npm, nvm](https://docs.npmjs.com/getting-started/installing-node)
+* [jq](https://stedolan.github.io/jq/) is recommended if using json.
 
 ### Setup
 
@@ -19,6 +20,8 @@ yarn test
 ```
 
 ### Example Usage
+
+openaq-quality-checks expects a list of items, either in json or csv.
 
 A set of default flags are configured in [`config.yml`](config.yml). The default flags are:
 
@@ -82,3 +85,8 @@ cat examples/addis-ababa-20180202.csv | ./index.js ${flags}
 ./index.js --infile examples/addis-ababa-20180202.json --remove-all
 ```
 
+#### Using the API call
+
+```
+curl 'https://api.openaq.org/v1/measurements?location=US%20Diplomatic%20Post:%20Addis%20Ababa%20School&date_from=2018-02-02&date_to=2018-02-06&limit=10' | jq '.results' | ./index.js | jq .
+```

--- a/README.md
+++ b/README.md
@@ -47,46 +47,45 @@ This configuration is merged with the default configuration, overriding fields t
 Note: Commands below require [jq](https://stedolan.github.io/jq/), but jq is just for pretty printing json. If you don't have jq installed, remove the trailing `| jq .`
 
 ```bash
-cat examples/addis-ababa-20180202.json | ./index.js | jq .
+cat examples/addis-ababa-20180202.json | quality-check | jq .
 # or
-./index.js --infile examples/addis-ababa-20180202.json | jq .
+quality-check --infile examples/addis-ababa-20180202.json | jq .
 ```
 
 #### Read and output CSV
 
 ```bash
-export flags='--input-format csv --output-format csv'
-cat examples/addis-ababa-20180202.csv | ./index.js ${flags}
+cat examples/addis-ababa-20180202.csv | quality-check --input-format csv --output-format csv
 # or
-./index.js --infile examples/addis-ababa-20180202.csv ${flags}
+quality-check --infile examples/addis-ababa-20180202.csv --input-format csv --output-format csv
 ```
 
 #### Override the default configuration
 
 ```
-./index.js --infile examples/addis-ababa-20180202.json --config tests/test-config.yml | jq .
+quality-check --infile examples/addis-ababa-20180202.json --config tests/test-config.yml | jq .
 ```
 
 #### Skip the 'N' and 'R' flags
 
 ```
-./index.js --infile examples/addis-ababa-20180202.json --skip N R | jq .
+quality-check --infile examples/addis-ababa-20180202.json --skip N R | jq .
 ```
 
 #### Remove all errors
 
 ```
-./index.js --infile examples/addis-ababa-20180202.json --remove E | jq .
+quality-check --infile examples/addis-ababa-20180202.json --remove E | jq .
 ```
 
 #### Remove all flagged items
 
 ```
-./index.js --infile examples/addis-ababa-20180202.json --remove-all
+quality-check --infile examples/addis-ababa-20180202.json --remove-all | jq .
 ```
 
 #### Using the API call
 
 ```
-curl 'https://api.openaq.org/v1/measurements?location=US%20Diplomatic%20Post:%20Addis%20Ababa%20School&date_from=2018-02-02&date_to=2018-02-06&limit=10' | jq '.results' | ./index.js | jq .
+curl 'https://api.openaq.org/v1/measurements?location=US%20Diplomatic%20Post:%20Addis%20Ababa%20School&date_from=2018-02-02&date_to=2018-02-06&limit=10' | jq '.results' | quality-check | jq .
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ Have an OpenAQ data quality concern or experience you would like to share? Pleas
 * [node, npm, nvm](https://docs.npmjs.com/getting-started/installing-node)
 * [jq](https://stedolan.github.io/jq/) is recommended if using json.
 
-### Setup
+### Installation
+
+```
+nvm use 8.9.4
+npm install openaq-quality-checker -g
+```
+
+### Development
 
 ```bash
 nvm use

--- a/examples/addis-ababa-20180202.json
+++ b/examples/addis-ababa-20180202.json
@@ -1,85 +1,80 @@
-{
-  "meta": {
-    "name": "openaq-api"
-  },
-  "results": [
-    {
-      "location": "US Diplomatic Post: Addis Ababa School",
-      "parameter": "pm25",
-      "date": {
-        "utc": "2018-02-03T00:00:00.000Z",
-        "local": "2018-02-03T03:00:00+03:00"
-      },
-      "value": -999,
-      "coordinates": {
-        "latitude": 8.996519,
-        "longitude": 38.725433
-      }
+[
+  {
+    "location": "US Diplomatic Post: Addis Ababa School",
+    "parameter": "pm25",
+    "date": {
+      "utc": "2018-02-03T00:00:00.000Z",
+      "local": "2018-02-03T03:00:00+03:00"
     },
-    {
-      "location": "US Diplomatic Post: Addis Ababa School",
-      "parameter": "pm25",
-      "date": {
-        "utc": "2018-02-03T00:00:00.000Z",
-        "local": "2018-02-03T03:00:00+03:00"
-      },
-      "value": -999,
-      "coordinates": {
-        "latitude": 1,
-        "longitude": 38.725433
-      }
-    },    
-    {
-      "location": "US Diplomatic Post: Addis Ababa School",
-      "parameter": "pm25",
-      "date": {
-        "utc": "2018-02-02T20:00:00.000Z",
-        "local": "2018-02-02T23:00:00+03:00"
-      },
-      "value": -999,
-      "coordinates": {
-        "latitude": 8.996519,
-        "longitude": 38.725433
-      }
-    },
-    {
-      "location": "US Diplomatic Post: Addis Ababa School",
-      "parameter": "pm25",
-      "date": {
-        "utc": "2018-02-02T17:00:00.000Z",
-        "local": "2018-02-02T20:00:00+03:00"
-      },
-      "value": 0,
-      "coordinates": {
-        "latitude": 8.996519,
-        "longitude": 38.725433
-      }
-    },
-    {
-      "location": "US Diplomatic Post: Addis Ababa School",
-      "parameter": "pm25",
-      "date": {
-        "utc": "2018-02-02T16:00:00.000Z",
-        "local": "2018-02-02T19:00:00+03:00"
-      },
-      "value": -999,
-      "coordinates": {
-        "latitude": 8.996519,
-        "longitude": 38.725433
-      }
-    },
-    {
-      "location": "US Diplomatic Post: Addis Ababa School",
-      "parameter": "pm25",
-      "date": {
-        "utc": "2018-02-02T15:00:00.000Z",
-        "local": "2018-02-02T18:00:00+03:00"
-      },
-      "value": -1,
-      "coordinates": {
-        "latitude": 8.996519,
-        "longitude": 38.725433
-      }
+    "value": -999,
+    "coordinates": {
+      "latitude": 8.996519,
+      "longitude": 38.725433
     }
-  ]
-}
+  },
+  {
+    "location": "US Diplomatic Post: Addis Ababa School",
+    "parameter": "pm25",
+    "date": {
+      "utc": "2018-02-03T00:00:00.000Z",
+      "local": "2018-02-03T03:00:00+03:00"
+    },
+    "value": -999,
+    "coordinates": {
+      "latitude": 1,
+      "longitude": 38.725433
+    }
+  },
+  {
+    "location": "US Diplomatic Post: Addis Ababa School",
+    "parameter": "pm25",
+    "date": {
+      "utc": "2018-02-02T20:00:00.000Z",
+      "local": "2018-02-02T23:00:00+03:00"
+    },
+    "value": -999,
+    "coordinates": {
+      "latitude": 8.996519,
+      "longitude": 38.725433
+    }
+  },
+  {
+    "location": "US Diplomatic Post: Addis Ababa School",
+    "parameter": "pm25",
+    "date": {
+      "utc": "2018-02-02T17:00:00.000Z",
+      "local": "2018-02-02T20:00:00+03:00"
+    },
+    "value": 0,
+    "coordinates": {
+      "latitude": 8.996519,
+      "longitude": 38.725433
+    }
+  },
+  {
+    "location": "US Diplomatic Post: Addis Ababa School",
+    "parameter": "pm25",
+    "date": {
+      "utc": "2018-02-02T16:00:00.000Z",
+      "local": "2018-02-02T19:00:00+03:00"
+    },
+    "value": -999,
+    "coordinates": {
+      "latitude": 8.996519,
+      "longitude": 38.725433
+    }
+  },
+  {
+    "location": "US Diplomatic Post: Addis Ababa School",
+    "parameter": "pm25",
+    "date": {
+      "utc": "2018-02-02T15:00:00.000Z",
+      "local": "2018-02-02T18:00:00+03:00"
+    },
+    "value": -1,
+    "coordinates": {
+      "latitude": 8.996519,
+      "longitude": 38.725433
+    }
+  }
+]

--- a/index.js
+++ b/index.js
@@ -59,10 +59,7 @@ function parseData(data) {
   if (argv['input-format'] === 'csv') {
     parsedData = parse(data, {columns: true, auto_parse: true});
   } else {
-    // TODO(aimee): Assumption about schema here should be flexible - that JSON
-    // data is nested under 'results' is an assumption we're interpreting data
-    // from the API.
-    parsedData = JSON.parse(data).results;
+    parsedData = JSON.parse(data);
   }
   return parsedData;  
 }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,14 @@
 #!/usr/bin/env node
+'use strict';
+
 const _ = require('lodash');
 const fs = require('fs');
 const parse = require('csv-parse/lib/sync');
-const path = require('path');
 const stringify = require('csv-stringify/lib/sync')
 const yaml = require('js-yaml');
 
-const baseDir = process.cwd();
-const configFile = path.join(baseDir, 'config.yml');
-const flaggerFile = path.join(baseDir, 'lib/flagger.js');
-
-const defaultConfig = yaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
-const Flagger = require(flaggerFile);
+const Flagger = require(`${__dirname}/lib/flagger`);
+const defaultConfig = yaml.safeLoad(fs.readFileSync(`${__dirname}/config.yml`, 'utf8'));
 
 // cat examples/simple.json | ./index.js
 // ./index.js --infile examples/simple.json

--- a/index.js
+++ b/index.js
@@ -2,11 +2,16 @@
 const _ = require('lodash');
 const fs = require('fs');
 const parse = require('csv-parse/lib/sync');
+const path = require('path');
 const stringify = require('csv-stringify/lib/sync')
 const yaml = require('js-yaml');
 
-const defaultConfig = yaml.safeLoad(fs.readFileSync('./config.yml', 'utf8'));
-const Flagger = require('./lib/flagger');
+const baseDir = process.cwd();
+const configFile = path.join(baseDir, 'config.yml');
+const flaggerFile = path.join(baseDir, 'lib/flagger.js');
+
+const defaultConfig = yaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
+const Flagger = require(flaggerFile);
 
 // cat examples/simple.json | ./index.js
 // ./index.js --infile examples/simple.json

--- a/lib/flagger.js
+++ b/lib/flagger.js
@@ -14,14 +14,15 @@ const objectPath = require('object-path');
  *
  * @param  {Object} `args` - configuration for a new Flagger instance.
  *   `args` requires:
- *     - `flag`    {String}: What string to use when adding a flag.
- *     - `type`    {String}: What type of check on values to run. Must be one of 'exact', 'set', 'range', or 'repeats'.
- *     - `value`   {Number}: When type is 'exact', `value` is required.
- *     - `values`  {Array}: When type is 'set', `values` is required.
- *     - `start`   {Object}: When type is 'range', `start` is required.
- *     - `end`     {Object}: When type is 'range', `end` is required.
- *     - `groupBy` {String|Array}: When type is 'repeats', `groupBy` is used to group the data by one or more fields.
- *.    - `orderBy` {String}: When type is 'repeats', `orderBy` is used to order data within a group.
+ *     - `flag`       {String}: What string to use when adding a flag.
+ *     - `type`       {String}: What type of check on values to run. Must be one of 'exact', 'set', 'range', or 'repeats'.
+ *     - `valueField` {String}: Optional - The name of the field to flag. Defaults to 'value'. Can use object-path syntax for nested fields.
+ *     - `value`      {Number}: When type is 'exact', `value` is required.
+ *     - `values`     {Array}: When type is 'set', `values` is required.
+ *     - `start`      {Object}: When type is 'range', `start` is required.
+ *     - `end`        {Object}: When type is 'range', `end` is required.
+ *     - `groupBy`    {String|Array}: When type is 'repeats', `groupBy` is used to group the data by one or more fields.
+ *.    - `orderBy`    {String}: When type is 'repeats', `orderBy` is used to order data within a group.
  * @return {Flagger}
  */
 class Flagger {
@@ -29,6 +30,7 @@ class Flagger {
     const schema = Joi.object().keys({
       flag: Joi.string().required(),
       type: Joi.any().valid('exact', 'set', 'range', 'repeats').required(),
+      valueField: Joi.string(),
       value: Joi.number().when('type', {is: 'exact', then: Joi.required()}),
       values: Joi.array().when('type', {is: 'set', then: Joi.required()}),
       start: Joi.object()
@@ -64,6 +66,7 @@ class Flagger {
     });
 
     this.config = args;
+    this.config.valueField = this.config.valueField || 'value';
   }
 
   /**
@@ -74,32 +77,33 @@ class Flagger {
    */
   addFlag(datum, additionalFlags = {}) {
     let addFlag = false;
+    const datumValue = objectPath.get(datum, this.config.valueField);
     switch (this.config.type) {
       case 'exact': {
-        addFlag = datum.value === this.config.value;
+        addFlag = datumValue === this.config.value;
         break;
       }
       case 'set': {
-        addFlag = this.config.values.includes(datum.value);
+        addFlag = this.config.values.includes(datumValue);
         break;
       }
       case 'range': {
         // inclusive
-        const isNumber = typeof(datum.value) === 'number';
+        const isNumber = typeof(datumValue) === 'number';
         const isGreaterOrEqualToStart = () => {
           if (!this.config.start) return true;
           if (this.config.start.exclusive === true) {
-            return datum.value > this.config.start.value;
+            return datumValue > this.config.start.value;
           } else {
-            return datum.value >= this.config.start.value;
+            return datumValue >= this.config.start.value;
           }
         }
         const isLessOrEqualToEnd = () => {
           if (!this.config.end) return true;
           if (this.config.end.exclusive === true) {
-            return datum.value < this.config.end.value;
+            return datumValue < this.config.end.value;
           } else {
-            return datum.value <= this.config.end.value;
+            return datumValue <= this.config.end.value;
           }
         }
         addFlag = isNumber && isGreaterOrEqualToStart() && isLessOrEqualToEnd();
@@ -139,13 +143,15 @@ class Flagger {
     let currentItem = {...data[0]};
     let nextItem = data[currentIndex+1];
     let currentSequence = [];
-    const currentValue = currentItem.value;
+    const currentValue = objectPath.get(currentItem, this.config.valueField);
+    let nextValue = objectPath.get(nextItem, this.config.valueField);
 
-    while (nextItem && currentValue === nextItem.value) {
+    while (nextValue !== undefined && currentValue === nextValue) {
       currentSequence.push(currentItem);
       currentIndex += 1;
       currentItem = {...data[currentIndex]};
       nextItem = {...data[currentIndex+1]};
+      nextValue = objectPath.get(nextItem, this.config.valueField);
     }
 
     if (currentIndex === 0) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openaq-quality-check",
+  "name": "openaq-quality-checker",
   "version": "1.0.0",
   "description": "CLI for adding flags to OpenAQ data",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "main": "./index.js",
     "test": "ava tests/*-test.js && echo '' && ./tests/integration.js"
   },
+  "preferGlobal": true,
+  "bin": {
+    "quality-check": "./index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openaq/openaq-quality-check.git"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openaq-quality-checks",
+  "name": "openaq-quality-check",
   "version": "1.0.0",
   "description": "CLI for adding flags to OpenAQ data",
   "main": "index.js",

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -2,7 +2,6 @@
 const assert = require('assert');
 const fs = require('fs');
 const parse = require('csv-parse/lib/sync');
-const path = require('path');
 const cp = require('child_process');
 
 const jsonTestFilename = 'examples/addis-ababa-20180202.json';


### PR DESCRIPTION
**Summary:** Adds bin command to make executable. Makes flagger more flexible to value field.

## Changes

* Use object-path to update flagger configuration so flagger doesn't require data values to be in a field named `value`
* Remove `results` from example json and index.js so that any json data array can be fed in
* Add executable, publish `openaq-quality-checker` to npm, update paths

## Test Plan
- [x] Unit tests
- [x] Adhoc testing

## TODO
I will update npm package name to `openaq-quality-checks` tomorrow, I force unpublished because of a path error and have to wait 24 hours before re-publishing.
