### PR TITLE
Use empty flags array

### DIFF
--- a/examples/flagged/addis-ababa-20180202-defaultFlags.json
+++ b/examples/flagged/addis-ababa-20180202-defaultFlags.json
@@ -49,7 +49,8 @@
     "coordinates": {
       "latitude": 8.996519,
       "longitude": 38.725433
-    }
+    },
+    "flags": []
   },
   {
     "location": "US Diplomatic Post: Addis Ababa School",

--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ function flagData(data) {
       flaggedData = flagger.flag(flaggedData);
     }
   });
-  // start with each item having an empty flags array, so that csv headers work.
+  // Every item needs a flags array, so that csv output will contain all
+  // headers. Without an empty flags array, if the first row doesn't have flags
+  // no flags will be output since the flags column won't be unrecognized.
   flaggedData.forEach(d => d.flags = d.flags || []);
   return flaggedData;
 }

--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ function flagData(data) {
       flaggedData = flagger.flag(flaggedData);
     }
   });
+  // start with each item having an empty flags array, so that csv headers work.
+  flaggedData.forEach(d => d.flags = d.flags || []);
   return flaggedData;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaq-quality-checks",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "CLI for adding flags to OpenAQ data",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Summary:** Use empty flags array

## Changes
* Every datum should have a flags array, empty or not, so CSV stringify recognizes the flags column header
* Update test data

## Test Plan
- [x] Unit tests
- [x] Adhoc testing
